### PR TITLE
Fix PHP 8.4 deprecation

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ["10.*", "11.*", "12.*"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/src/MustVerifyNewEmail.php
+++ b/src/MustVerifyNewEmail.php
@@ -14,10 +14,10 @@ trait MustVerifyNewEmail
      * to the new email address.
      *
      * @param string $email
-     * @param callable $withMailable
+     * @param callable|null $withMailable
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function newEmail(string $email, callable $withMailable = null): ?Model
+    public function newEmail(string $email, ?callable $withMailable = null): ?Model
     {
         if ($this->getEmailForVerification() === $email && $this->hasVerifiedEmail()) {
             return null;
@@ -81,10 +81,10 @@ trait MustVerifyNewEmail
      * Sends the VerifyNewEmail Mailable to the new email address.
      *
      * @param \Illuminate\Database\Eloquent\Model $pendingUserEmail
-     * @param callable $withMailable
+     * @param callable|null $withMailable
      * @return mixed
      */
-    public function sendPendingEmailVerificationMail(Model $pendingUserEmail, callable $withMailable = null)
+    public function sendPendingEmailVerificationMail(Model $pendingUserEmail, ?callable $withMailable = null)
     {
         $mailableClass = config('verify-new-email.mailable_for_first_verification');
 


### PR DESCRIPTION
When using PHP 8.4 the following deprecations warnings are displayed.

```
DEPRECATED  ProtoneMedia\LaravelVerifyNewEmail\MustVerifyNewEmail::newEmail(): Implicitly marking parameter $withMailable as nullable is deprecated, the explicit nullable type must be used instead in vendor/protonemedia/laravel-verify-new-email/src/MustVerifyNewEmail.php on line 20.

DEPRECATED  ProtoneMedia\LaravelVerifyNewEmail\MustVerifyNewEmail::sendPendingEmailVerificationMail(): Implicitly marking parameter $withMailable as nullable is deprecated, the explicit nullable type must be used instead in vendor/protonemedia/laravel-verify-new-email/src/MustVerifyNewEmail.php on line 87.
```

With using the explicit nullable type introduced in **PHP 7.1**, this is easy to fix without breaking anything else.